### PR TITLE
Add "Add bookmark" endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,17 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "body-parser": "^1.20.1",
         "dotenv": "^16.0.3",
         "express": "^4.18.2",
         "knex": "^2.3.0",
-        "pg": "^8.8.0"
+        "pg": "^8.8.0",
+        "uuid": "^9.0.0"
       },
       "devDependencies": {
         "@types/express": "^4.17.14",
         "@types/node": "^18.11.6",
+        "@types/uuid": "^8.3.4",
         "nodemon": "^2.0.20",
         "ts-node": "^10.9.1",
         "typescript": "^4.8.4"
@@ -158,6 +161,12 @@
         "@types/mime": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+      "dev": true
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
@@ -1538,6 +1547,14 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -1701,6 +1718,12 @@
         "@types/mime": "*",
         "@types/node": "*"
       }
+    },
+    "@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+      "dev": true
     },
     "abbrev": {
       "version": "1.1.1",
@@ -2680,6 +2703,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="
+    },
+    "uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
     },
     "v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -13,14 +13,17 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "body-parser": "^1.20.1",
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
     "knex": "^2.3.0",
-    "pg": "^8.8.0"
+    "pg": "^8.8.0",
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.14",
     "@types/node": "^18.11.6",
+    "@types/uuid": "^8.3.4",
     "nodemon": "^2.0.20",
     "ts-node": "^10.9.1",
     "typescript": "^4.8.4"

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,23 @@
+export class CustomError extends Error {
+    public type = "";
+    public errorMessage = "";
+};
+
+
+export class BookmarkError extends CustomError {
+    public constructor(...args: any[]) {
+        super(...args);
+        Error.captureStackTrace(this, BookmarkError);
+        this.type = "bookmark_error";
+        this.errorMessage = args[0];
+    }
+}
+
+export class BookmarkAlreadyExistsError extends CustomError {
+    public constructor(...args: any[]) {
+        super(...args);
+        Error.captureStackTrace(this, BookmarkAlreadyExistsError);
+        this.type = "bookmark_already_exists";
+        this.errorMessage = args[0];
+    }
+};

--- a/src/handlers/Bookmarks/index.ts
+++ b/src/handlers/Bookmarks/index.ts
@@ -28,7 +28,10 @@ export default class BookmarksHandler {
         const { url, title } = req.body.bookmark;
         // Save bookmark
         const bookmark = await this.bookmarksService.addBookmark(url, title);
-        // Deal with errors if any
+        // Deal with errors if needed
+        if (bookmark instanceof Error) {
+            return res.status(400).json({ message: bookmark.message });
+        }
         // Return in the appropriate format
         return res.status(200).send({ bookmark });
     };

--- a/src/handlers/Bookmarks/index.ts
+++ b/src/handlers/Bookmarks/index.ts
@@ -9,11 +9,24 @@ export default class BookmarksHandler {
     }
 
     public getBookmarks = async (req: Request, res: Response) => {
-        // Validate query params if needed
+        // Validate input if needed
         // Get bookmarks through the service
         const bookmarks = await this.bookmarksService.getBookmarks();
         // Deal with errors if any
         // Return in the appropriate format
-        return res.json({ bookmarks });
+        return res.status(200).json({ bookmarks });
+    };
+
+    public addBookmark = async (req: Request, res: Response) => {
+        // Validate input
+        if (!req.body?.bookmark?.url) {
+            return res.status(400).json({ message: "missing URL" });
+        }
+        const { url, title } = req.body.bookmark;
+        // Save bookmark
+        const bookmark = await this.bookmarksService.addBookmark(url, title);
+        // Deal with errors if any
+        // Return in the appropriate format
+        return res.status(200).send({ bookmark });
     };
 };

--- a/src/handlers/Bookmarks/index.ts
+++ b/src/handlers/Bookmarks/index.ts
@@ -1,4 +1,3 @@
-import { BlobOptions } from "buffer";
 import { Request, Response } from "express";
 import BookmarksService from "../../services/Bookmarks";
 

--- a/src/handlers/Bookmarks/index.ts
+++ b/src/handlers/Bookmarks/index.ts
@@ -1,3 +1,4 @@
+import { BlobOptions } from "buffer";
 import { Request, Response } from "express";
 import BookmarksService from "../../services/Bookmarks";
 
@@ -22,6 +23,9 @@ export default class BookmarksHandler {
         if (!req.body?.bookmark?.url) {
             return res.status(400).json({ message: "missing URL" });
         }
+        if (!this.isValidUrl(req.body.bookmark.url)) {
+            return res.status(400).json({ message: "invalid URL provided" });
+        }
         const { url, title } = req.body.bookmark;
         // Save bookmark
         const bookmark = await this.bookmarksService.addBookmark(url, title);
@@ -29,4 +33,14 @@ export default class BookmarksHandler {
         // Return in the appropriate format
         return res.status(200).send({ bookmark });
     };
+
+    private isValidUrl(url: string): boolean {
+        try {
+            new URL(url);
+        }
+        catch (err) {
+            return false;
+        }
+        return true;
+    }
 };

--- a/src/handlers/Bookmarks/index.ts
+++ b/src/handlers/Bookmarks/index.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from "express";
+import { BookmarkAlreadyExistsError, BookmarkError } from "../../errors";
 import BookmarksService from "../../services/Bookmarks";
 
 export default class BookmarksHandler {
@@ -13,6 +14,9 @@ export default class BookmarksHandler {
         // Get bookmarks through the service
         const bookmarks = await this.bookmarksService.getBookmarks();
         // Deal with errors if any
+        if (bookmarks instanceof BookmarkError) {
+            return res.status(500).json({ message: bookmarks.errorMessage });
+        }
         // Return in the appropriate format
         return res.status(200).json({ bookmarks });
     };
@@ -29,8 +33,11 @@ export default class BookmarksHandler {
         // Save bookmark
         const bookmark = await this.bookmarksService.addBookmark(url, title);
         // Deal with errors if needed
-        if (bookmark instanceof Error) {
-            return res.status(400).json({ message: bookmark.message });
+        if (bookmark instanceof BookmarkAlreadyExistsError) {
+            return res.status(400).json({ message: bookmark.errorMessage });
+        }
+        if (bookmark instanceof BookmarkError) {
+            return res.status(500).json({ message: bookmark.errorMessage });
         }
         // Return in the appropriate format
         return res.status(200).send({ bookmark });

--- a/src/handlers/Bookmarks/index.ts
+++ b/src/handlers/Bookmarks/index.ts
@@ -23,13 +23,13 @@ export default class BookmarksHandler {
 
     public addBookmark = async (req: Request, res: Response) => {
         // Validate input
-        if (!req.body?.bookmark?.url) {
+        if (!req.body?.url) {
             return res.status(400).json({ message: "missing URL" });
         }
-        if (!this.isValidUrl(req.body.bookmark.url)) {
+        if (!this.isValidUrl(req.body.url)) {
             return res.status(400).json({ message: "invalid URL provided" });
         }
-        const { url, title } = req.body.bookmark;
+        const { url, title } = req.body;
         // Save bookmark
         const bookmark = await this.bookmarksService.addBookmark(url, title);
         // Deal with errors if needed

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import express from 'express';
+import bodyParser from 'body-parser';
 import dotenv from 'dotenv';
 import { knex as KnexFactory } from "knex";
 
@@ -12,6 +13,7 @@ dotenv.config();
 // Initialize server
 const app = express();
 const SERVER_PORT = process.env.SERVER_PORT;
+app.use(bodyParser.json());
 
 // Initialize DB
 const database = KnexFactory({
@@ -33,6 +35,7 @@ const bookmarksHandler = new BookmarksHandler(bookmarksService);
 
 // Bind routes to handlers
 app.get('/bookmarks', bookmarksHandler.getBookmarks);
+app.post('/bookmark', bookmarksHandler.addBookmark);
 
 // Start server
 app.listen(SERVER_PORT, () => {

--- a/src/services/Bookmarks/index.ts
+++ b/src/services/Bookmarks/index.ts
@@ -1,3 +1,4 @@
+import BookmarksHandler from "../../handlers/Bookmarks";
 import BookmarksStore from "../../stores/Bookmarks";
 
 export default class BookmarksService {
@@ -10,4 +11,9 @@ export default class BookmarksService {
     public getBookmarks = async () => {
         return await this.bookmarksStore.getBookmarks();
     };
+
+    public addBookmark = async (url: string, title: string) => {
+        const bookmark = this.bookmarksStore.addBookmark({ url, title });
+        return bookmark;
+    }
 };

--- a/src/services/Bookmarks/index.ts
+++ b/src/services/Bookmarks/index.ts
@@ -1,4 +1,3 @@
-import BookmarksHandler from "../../handlers/Bookmarks";
 import BookmarksStore from "../../stores/Bookmarks";
 
 export default class BookmarksService {

--- a/src/stores/Bookmarks/index.ts
+++ b/src/stores/Bookmarks/index.ts
@@ -1,6 +1,7 @@
 import { Knex } from "knex";
 import { Bookmark } from "../../interfaces/Bookmark";
 import { v4 as uuidv4 } from "uuid";
+import { BookmarkAlreadyExistsError, BookmarkError } from "../../errors";
 
 export default class BookmarksStore {
     private database: Knex;
@@ -14,12 +15,16 @@ export default class BookmarksStore {
         return this.database<Bookmark, Bookmark[]>(this.TABLE_NAME);
     }
 
-    public getBookmarks = async (): Promise<Bookmark[]> => {
-        const bookmarks = await this.getTable().orderBy("created_at", "desc");
-        return bookmarks;
+    public getBookmarks = async (): Promise<Bookmark[] | BookmarkError> => {
+        try {
+            return await this.getTable().orderBy("created_at", "desc");
+        }
+        catch (err) {
+            return new BookmarkError("There was an error retrieving the bookmarks");
+        }
     };
 
-    public addBookmark = async ({ url, title }: { url: string, title?: string }): Promise<Bookmark | Error> => {
+    public addBookmark = async ({ url, title }: { url: string, title?: string }): Promise<Bookmark | BookmarkAlreadyExistsError | BookmarkError> => {
         try {
             const bookmark = await this.getTable().insert({
                 id: uuidv4(),
@@ -34,9 +39,9 @@ export default class BookmarksStore {
         } catch (err) {
             //@ts-ignore
             if (err?.constraint === 'bookmarks_url_unique') {
-                return new Error("This URL already exists");
+                return new BookmarkAlreadyExistsError("This URL already exists");
             }
-            return new Error("There was an error saving the bookmark");
+            return new BookmarkError("There was an error saving the bookmark");
         }
     };
 }

--- a/src/stores/Bookmarks/index.ts
+++ b/src/stores/Bookmarks/index.ts
@@ -19,16 +19,24 @@ export default class BookmarksStore {
         return bookmarks;
     };
 
-    public addBookmark = async ({ url, title }: { url: string, title?: string }): Promise<Bookmark> => {
-        const bookmark = await this.getTable().insert({
-            id: uuidv4(),
-            url,
-            title,
-        }).returning('id');
-        return {
-            id: bookmark[0].id,
-            url,
-            title,
-        };
+    public addBookmark = async ({ url, title }: { url: string, title?: string }): Promise<Bookmark | Error> => {
+        try {
+            const bookmark = await this.getTable().insert({
+                id: uuidv4(),
+                url,
+                title,
+            }).returning('id');
+            return {
+                id: bookmark[0].id,
+                url,
+                title,
+            };
+        } catch (err) {
+            //@ts-ignore
+            if (err?.constraint === 'bookmarks_url_unique') {
+                return new Error("This URL already exists");
+            }
+            return new Error("There was an error saving the bookmark");
+        }
     };
 }

--- a/src/stores/Bookmarks/index.ts
+++ b/src/stores/Bookmarks/index.ts
@@ -1,5 +1,6 @@
 import { Knex } from "knex";
 import { Bookmark } from "../../interfaces/Bookmark";
+import { v4 as uuidv4 } from "uuid";
 
 export default class BookmarksStore {
     private database: Knex;
@@ -17,4 +18,17 @@ export default class BookmarksStore {
         const bookmarks = await this.getTable().orderBy("created_at", "desc");
         return bookmarks;
     };
-};
+
+    public addBookmark = async ({ url, title }: { url: string, title?: string }): Promise<Bookmark> => {
+        const bookmark = await this.getTable().insert({
+            id: uuidv4(),
+            url,
+            title,
+        }).returning('id');
+        return {
+            id: bookmark[0].id,
+            url,
+            title,
+        };
+    };
+}


### PR DESCRIPTION
This PR introduces a new endpoint that allows you to create a new bookmark.

A `POST` request to `/bookmark` should add a new bookmark "for that user" (the user concept doesn't exist yet though)

The body of the request should look like this:

```
{ 
    "url": "https://my.url.com",
    "title": "Example title"
}
```

Where:

- `url` has to be a valid URL, and it's mandatory. It's also unique so you cannot have two bookmarks with the same URL.
- `title` has to be a string, but it's not mandatory.


Additionally, a new collection of `Error` classes has been introduced to make error handling more uniform and readable.

