### PR TITLE
Add missing CRUD endpoints for bookmarks and labels

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -13,6 +13,15 @@ export class BookmarkError extends CustomError {
     }
 }
 
+export class BookmarkDoesNotExistError extends CustomError {
+    public constructor(...args: any[]) {
+        super(...args);
+        Error.captureStackTrace(this, BookmarkDoesNotExistError);
+        this.type = "bookmark-does-not-exist";
+        this.errorMessage = args[0];
+    }
+}
+
 export class BookmarkAlreadyExistsError extends CustomError {
     public constructor(...args: any[]) {
         super(...args);

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -98,7 +98,7 @@ export class LabelDoesNotExistError extends CustomError {
     public constructor(...args: any[]) {
         super(...args);
         Error.captureStackTrace(this, LabelDoesNotExistError);
-        this.type = "label-not-exists";
+        this.type = "label-does-not-exist";
         this.errorMessage = args[0];
     }
 }

--- a/src/handlers/Bookmarks/index.ts
+++ b/src/handlers/Bookmarks/index.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from "express";
-import { BookmarkAlreadyExistsError, BookmarkAlreadyHasLabelError, BookmarkError, BookmarkDoesNotHaveLabelError, BookmarkDoesNotExistError } from "../../errors";
+import { BookmarkAlreadyExistsError, BookmarkAlreadyHasLabelError, BookmarkError, BookmarkDoesNotHaveLabelError, BookmarkDoesNotExistError, LabelDoesNotExistError } from "../../errors";
 import BookmarksService from "../../services/Bookmarks";
 import LabelsService from "../../services/Labels";
 
@@ -19,11 +19,20 @@ export default class BookmarksHandler {
         let labelId;
         if (req?.query?.labelId) {
             labelId = req?.query?.labelId as string;
-            if (!this.labelsService.isOwner({ labelId, userId })) {
+            const isLabelOwner = this.labelsService.isOwner({ labelId, userId });
+            if (isLabelOwner instanceof LabelDoesNotExistError) {
+                return res.status(404).json({
+                    error: {
+                        type: isLabelOwner.type,
+                        message: isLabelOwner.errorMessage
+                    }
+                });
+            }
+            if (!isLabelOwner) {
                 return res.status(403).json({
                     error: {
-                        type: "incorrect-label",
-                        message: "User does not own this label or it does not exist"
+                        type: "forbidden-access-to-label",
+                        message: "User does not own this label"
                     }
                 });
             }
@@ -222,20 +231,36 @@ export default class BookmarksHandler {
 
         // Check ownership of both entities
         const isBookmarkOwner = await this.bookmarksService.isOwner({ bookmarkId, userId });
+        if (isBookmarkOwner instanceof BookmarkDoesNotExistError) {
+            return res.status(404).json({
+                error: {
+                    type: isBookmarkOwner.type,
+                    message: isBookmarkOwner.errorMessage
+                }
+            });
+        }
         if (!isBookmarkOwner) {
             return res.status(403).json({
                 error: {
-                    type: "incorrect-bookmark",
-                    message: "User does not own this bookmark or it does not exist"
+                    type: "forbidden-access-to-bookmark",
+                    message: "User does not own this bookmark"
                 }
             });
         }
         const isLabelOwner = await this.labelsService.isOwner({ labelId, userId });
+        if (isLabelOwner instanceof LabelDoesNotExistError) {
+            return res.status(404).json({
+                error: {
+                    type: isLabelOwner.type,
+                    message: isLabelOwner.errorMessage
+                }
+            });
+        }
         if (!isLabelOwner) {
             return res.status(403).json({
                 error: {
-                    type: "incorrect-label",
-                    message: "User does not own this label or it does not exist"
+                    type: "forbidden-access-to-label",
+                    message: "User does not own this label"
                 }
             });
         }
@@ -280,20 +305,36 @@ export default class BookmarksHandler {
 
         // Check ownership of both entities
         const isBookmarkOwner = await this.bookmarksService.isOwner({ bookmarkId, userId });
+        if (isBookmarkOwner instanceof BookmarkDoesNotExistError) {
+            return res.status(404).json({
+                error: {
+                    type: isBookmarkOwner.type,
+                    message: isBookmarkOwner.errorMessage
+                }
+            });
+        }
         if (!isBookmarkOwner) {
             return res.status(403).json({
                 error: {
-                    type: "incorrect-bookmark",
-                    message: "User does not own this bookmark or it does not exist"
+                    type: "forbidden-access-to-bookmark",
+                    message: "User does not own this bookmark"
                 }
             });
         }
         const isLabelOwner = await this.labelsService.isOwner({ labelId, userId });
+        if (isLabelOwner instanceof LabelDoesNotExistError) {
+            return res.status(404).json({
+                error: {
+                    type: isLabelOwner.type,
+                    message: isLabelOwner.errorMessage
+                }
+            });
+        }
         if (!isLabelOwner) {
             return res.status(403).json({
                 error: {
-                    type: "incorrect-label",
-                    message: "User does not own this label or it does not exist"
+                    type: "forbidden-access-to-label",
+                    message: "User does not own this label"
                 }
             });
         }

--- a/src/handlers/Bookmarks/tests/index.test.ts
+++ b/src/handlers/Bookmarks/tests/index.test.ts
@@ -634,7 +634,7 @@ test('addLabelToBookmark should return an error when the label does not exist', 
     await bookmarksHandler.addLabelToBookmark(request, response);
     // @ts-ignore
     expect(statusMocked).toHaveBeenCalledWith(404);
-    expect(jsonMocked.mock.lastCall[0].error.type).toBe("label-not-exists");
+    expect(jsonMocked.mock.lastCall[0].error.type).toBe("label-does-not-exist");
 });
 
 test('addLabelToBookmark should return an error when the bookmark already has the label', async () => {
@@ -849,7 +849,7 @@ test('removeLabelFromBookmark should return an error when the label does not exi
     await bookmarksHandler.removeLabelFromBookmark(request, response);
     // @ts-ignore
     expect(statusMocked).toHaveBeenCalledWith(404);
-    expect(jsonMocked.mock.lastCall[0].error.type).toBe("label-not-exists");
+    expect(jsonMocked.mock.lastCall[0].error.type).toBe("label-does-not-exist");
 });
 
 test('removeLabelFromBookmark should return an error when the bookmark does not have the label', async () => {

--- a/src/handlers/Bookmarks/tests/index.test.ts
+++ b/src/handlers/Bookmarks/tests/index.test.ts
@@ -281,7 +281,7 @@ test('deleteBookmark should handle an unknown error when deleting the bookmark',
     expect(jsonMocked.mock.lastCall[0].error.type).toBe("bookmark-error");
 });
 
-test('deleteBookmark should call the service with the right parameters and return the new bookmark', async () => {
+test('deleteBookmark should call the service with the right parameters and return 200', async () => {
     const jsonMocked = jest.fn();
     const sendMocked = jest.fn();
     const statusMocked = jest.fn().mockReturnValue({ json: jsonMocked, send: sendMocked });

--- a/src/handlers/Bookmarks/tests/index.test.ts
+++ b/src/handlers/Bookmarks/tests/index.test.ts
@@ -1,7 +1,7 @@
 import BookmarksHandler from '../index';
 import BookmarksService from '../../../services/Bookmarks';
 import LabelsService from '../../../services/Labels';
-import { BookmarkAlreadyExistsError, BookmarkAlreadyHasLabelError, BookmarkDoesNotExistError, BookmarkDoesNotHaveLabelError, BookmarkError } from '../../../errors';
+import { BookmarkAlreadyExistsError, BookmarkAlreadyHasLabelError, BookmarkDoesNotExistError, BookmarkDoesNotHaveLabelError, BookmarkError, LabelDoesNotExistError } from '../../../errors';
 import { randomUUID } from 'crypto';
 
 let bookmarksHandler: BookmarksHandler;
@@ -529,7 +529,7 @@ test('addLabelToBookmark should return an error when no labelId is provided', as
     expect(jsonMocked.mock.lastCall[0].error.type).toBe("missing-label-id");
 });
 
-test('addLabelToBookmark should return an error when the bookmark is not owned by the user or does not exist', async () => {
+test('addLabelToBookmark should return an error when the bookmark is not owned by the user', async () => {
     const jsonMocked = jest.fn();
     const statusMocked = jest.fn().mockReturnValue({ json: jsonMocked });
     const request: any = {
@@ -552,10 +552,36 @@ test('addLabelToBookmark should return an error when the bookmark is not owned b
     await bookmarksHandler.addLabelToBookmark(request, response);
     // @ts-ignore
     expect(statusMocked).toHaveBeenCalledWith(403);
-    expect(jsonMocked.mock.lastCall[0].error.type).toBe("incorrect-bookmark");
+    expect(jsonMocked.mock.lastCall[0].error.type).toBe("forbidden-access-to-bookmark");
 });
 
-test('addLabelToBookmark should return an error when the label is not owned by the user or does not exist', async () => {
+test('addLabelToBookmark should return an error when the bookmark does not exist', async () => {
+    const jsonMocked = jest.fn();
+    const statusMocked = jest.fn().mockReturnValue({ json: jsonMocked });
+    const request: any = {
+        ...getMockedUser(),
+        params: {
+            bookmarkId: randomUUID(),
+            labelId: randomUUID(),
+        }
+    };
+    const response: any = {
+        status: statusMocked
+    };
+
+    // @ts-ignore
+    bookmarksService.addLabelToBookmark = jest.fn();
+    // @ts-ignore
+    bookmarksService.isOwner = jest.fn().mockReturnValue(new BookmarkDoesNotExistError());
+
+    // @ts-ignore
+    await bookmarksHandler.addLabelToBookmark(request, response);
+    // @ts-ignore
+    expect(statusMocked).toHaveBeenCalledWith(404);
+    expect(jsonMocked.mock.lastCall[0].error.type).toBe("bookmark-does-not-exist");
+});
+
+test('addLabelToBookmark should return an error when the label is not owned by the user', async () => {
     const jsonMocked = jest.fn();
     const statusMocked = jest.fn().mockReturnValue({ json: jsonMocked });
     const request: any = {
@@ -580,7 +606,35 @@ test('addLabelToBookmark should return an error when the label is not owned by t
     await bookmarksHandler.addLabelToBookmark(request, response);
     // @ts-ignore
     expect(statusMocked).toHaveBeenCalledWith(403);
-    expect(jsonMocked.mock.lastCall[0].error.type).toBe("incorrect-label");
+    expect(jsonMocked.mock.lastCall[0].error.type).toBe("forbidden-access-to-label");
+});
+
+test('addLabelToBookmark should return an error when the label does not exist', async () => {
+    const jsonMocked = jest.fn();
+    const statusMocked = jest.fn().mockReturnValue({ json: jsonMocked });
+    const request: any = {
+        ...getMockedUser(),
+        params: {
+            bookmarkId: randomUUID(),
+            labelId: randomUUID(),
+        }
+    };
+    const response: any = {
+        status: statusMocked
+    };
+
+    // @ts-ignore
+    bookmarksService.addLabelToBookmark = jest.fn();
+    // @ts-ignore
+    bookmarksService.isOwner = jest.fn().mockReturnValue(true);
+    // @ts-ignore
+    labelsService.isOwner = jest.fn().mockReturnValue(new LabelDoesNotExistError());
+
+    // @ts-ignore
+    await bookmarksHandler.addLabelToBookmark(request, response);
+    // @ts-ignore
+    expect(statusMocked).toHaveBeenCalledWith(404);
+    expect(jsonMocked.mock.lastCall[0].error.type).toBe("label-not-exists");
 });
 
 test('addLabelToBookmark should return an error when the bookmark already has the label', async () => {
@@ -690,7 +744,7 @@ test('removeLabelFromBookmark should return an error when no labelId is provided
     expect(jsonMocked.mock.lastCall[0].error.type).toBe("missing-label-id");
 });
 
-test('removeLabelFromBookmark should return an error when the bookmark is not owned by the user or does not exist', async () => {
+test('removeLabelFromBookmark should return an error when the bookmark is not owned by the user', async () => {
     const jsonMocked = jest.fn();
     const statusMocked = jest.fn().mockReturnValue({ json: jsonMocked });
     const request: any = {
@@ -713,10 +767,36 @@ test('removeLabelFromBookmark should return an error when the bookmark is not ow
     await bookmarksHandler.removeLabelFromBookmark(request, response);
     // @ts-ignore
     expect(statusMocked).toHaveBeenCalledWith(403);
-    expect(jsonMocked.mock.lastCall[0].error.type).toBe("incorrect-bookmark");
+    expect(jsonMocked.mock.lastCall[0].error.type).toBe("forbidden-access-to-bookmark");
 });
 
-test('removeLabelFromBookmark should return an error when the label is not owned by the user or does not exist', async () => {
+test('removeLabelFromBookmark should return an error when the bookmark does not exist', async () => {
+    const jsonMocked = jest.fn();
+    const statusMocked = jest.fn().mockReturnValue({ json: jsonMocked });
+    const request: any = {
+        ...getMockedUser(),
+        params: {
+            bookmarkId: randomUUID(),
+            labelId: randomUUID(),
+        }
+    };
+    const response: any = {
+        status: statusMocked
+    };
+
+    // @ts-ignore
+    bookmarksService.removeLabelFromBookmark = jest.fn();
+    // @ts-ignore
+    bookmarksService.isOwner = jest.fn().mockReturnValue(new BookmarkDoesNotExistError());
+
+    // @ts-ignore
+    await bookmarksHandler.removeLabelFromBookmark(request, response);
+    // @ts-ignore
+    expect(statusMocked).toHaveBeenCalledWith(404);
+    expect(jsonMocked.mock.lastCall[0].error.type).toBe("bookmark-does-not-exist");
+});
+
+test('removeLabelFromBookmark should return an error when the label is not owned by the user', async () => {
     const jsonMocked = jest.fn();
     const statusMocked = jest.fn().mockReturnValue({ json: jsonMocked });
     const request: any = {
@@ -741,7 +821,35 @@ test('removeLabelFromBookmark should return an error when the label is not owned
     await bookmarksHandler.removeLabelFromBookmark(request, response);
     // @ts-ignore
     expect(statusMocked).toHaveBeenCalledWith(403);
-    expect(jsonMocked.mock.lastCall[0].error.type).toBe("incorrect-label");
+    expect(jsonMocked.mock.lastCall[0].error.type).toBe("forbidden-access-to-label");
+});
+
+test('removeLabelFromBookmark should return an error when the label does not exist', async () => {
+    const jsonMocked = jest.fn();
+    const statusMocked = jest.fn().mockReturnValue({ json: jsonMocked });
+    const request: any = {
+        ...getMockedUser(),
+        params: {
+            bookmarkId: randomUUID(),
+            labelId: randomUUID(),
+        }
+    };
+    const response: any = {
+        status: statusMocked
+    };
+
+    // @ts-ignore
+    bookmarksService.removeLabelFromBookmark = jest.fn();
+    // @ts-ignore
+    bookmarksService.isOwner = jest.fn().mockReturnValue(true);
+    // @ts-ignore
+    labelsService.isOwner = jest.fn().mockReturnValue(new LabelDoesNotExistError());
+
+    // @ts-ignore
+    await bookmarksHandler.removeLabelFromBookmark(request, response);
+    // @ts-ignore
+    expect(statusMocked).toHaveBeenCalledWith(404);
+    expect(jsonMocked.mock.lastCall[0].error.type).toBe("label-not-exists");
 });
 
 test('removeLabelFromBookmark should return an error when the bookmark does not have the label', async () => {

--- a/src/handlers/Labels/index.ts
+++ b/src/handlers/Labels/index.ts
@@ -89,8 +89,8 @@ export default class LabelsHandler {
         if (!isLabelOwner) {
             return res.status(403).json({
                 error: {
-                    type: "incorrect-label",
-                    message: "User does not own this label or it does not exist"
+                    type: "forbidden-access-to-label",
+                    message: "User does not own this label"
                 }
             });
         }

--- a/src/handlers/Labels/tests/index.test.ts
+++ b/src/handlers/Labels/tests/index.test.ts
@@ -181,7 +181,7 @@ test('updateLabel should return an error when the label does not exist', async (
     await labelsHandler.updateLabel(request, response);
     // @ts-ignore
     expect(statusMocked).toHaveBeenCalledWith(404);
-    expect(jsonMocked.mock.lastCall[0].error.type).toBe("label-not-exists");
+    expect(jsonMocked.mock.lastCall[0].error.type).toBe("label-does-not-exist");
 });
 
 test('updateLabel should return an error when the label is not owned by the user', async () => {
@@ -341,7 +341,7 @@ test('deleteLabel should return an error when the label does not exist', async (
     await labelsHandler.deleteLabel(request, response);
     // @ts-ignore
     expect(statusMocked).toHaveBeenCalledWith(404);
-    expect(jsonMocked.mock.lastCall[0].error.type).toBe("label-not-exists");
+    expect(jsonMocked.mock.lastCall[0].error.type).toBe("label-does-not-exist");
 });
 
 test('deleteLabel should handle an unknown error when deleting the label', async () => {

--- a/src/handlers/Labels/tests/index.test.ts
+++ b/src/handlers/Labels/tests/index.test.ts
@@ -135,6 +135,143 @@ test('createLabel should handle an unknown error when creating the label', async
     expect(jsonMocked.mock.lastCall[0].error.type).toBe("label-creation-error");
 });
 
+test('updateLabel should return an error when provided an invalid name', async () => {
+    const jsonMocked = jest.fn();
+    const statusMocked = jest.fn().mockReturnValue({ json: jsonMocked });
+    const request: any = {
+        ...getMockedUser(),
+        params: {
+            labelId: randomUUID(),
+        },
+        body: {
+            name: "",
+        }
+    };
+    const response: any = {
+        status: statusMocked
+    };
+
+    // @ts-ignore
+    await labelsHandler.updateLabel(request, response);
+    // @ts-ignore
+    expect(statusMocked).toHaveBeenCalledWith(400);
+    expect(jsonMocked.mock.lastCall[0].error.type).toBe("invalid-name");
+});
+
+test('updateLabel should return an error when the label does not exist', async () => {
+    const jsonMocked = jest.fn();
+    const statusMocked = jest.fn().mockReturnValue({ json: jsonMocked });
+    const request: any = {
+        ...getMockedUser(),
+        params: {
+            labelId: randomUUID()
+        },
+        body: {
+            name: "newerLabel",
+        }
+    };
+    const response: any = {
+        status: statusMocked
+    };
+
+    // @ts-ignore
+    labelsService.isOwner = jest.fn().mockReturnValue(new LabelDoesNotExistError());
+
+    // @ts-ignore
+    await labelsHandler.updateLabel(request, response);
+    // @ts-ignore
+    expect(statusMocked).toHaveBeenCalledWith(404);
+    expect(jsonMocked.mock.lastCall[0].error.type).toBe("label-not-exists");
+});
+
+test('updateLabel should return an error when the label is not owned by the user', async () => {
+    const jsonMocked = jest.fn();
+    const statusMocked = jest.fn().mockReturnValue({ json: jsonMocked });
+    const request: any = {
+        ...getMockedUser(),
+        params: {
+            labelId: randomUUID()
+        },
+        body: {
+            name: "newerLabel",
+        }
+    };
+    const response: any = {
+        status: statusMocked
+    };
+
+    // @ts-ignore
+    labelsService.updateLabel = jest.fn();
+    // @ts-ignore
+    labelsService.isOwner = jest.fn().mockReturnValue(false);
+
+    // @ts-ignore
+    await labelsHandler.updateLabel(request, response);
+    // @ts-ignore
+    expect(statusMocked).toHaveBeenCalledWith(403);
+    expect(jsonMocked.mock.lastCall[0].error.type).toBe("forbidden-access-to-label");
+});
+
+test('updateLabel should handle an unknown error when creating the label', async () => {
+    const jsonMocked = jest.fn();
+    const statusMocked = jest.fn().mockReturnValue({ json: jsonMocked });
+    const request: any = {
+        ...getMockedUser(),
+        params: {
+            labelId: randomUUID(),
+        },
+        body: {
+            name: "newerLabel",
+        }
+    };
+    const response: any = {
+        status: statusMocked
+    };
+
+    const returnValue = new LabelError();
+    // @ts-ignore
+    labelsService.updateLabel = jest.fn().mockReturnValue(returnValue);
+    // @ts-ignore
+    labelsService.isOwner = jest.fn().mockReturnValue(true);
+
+    // @ts-ignore
+    await labelsHandler.updateLabel(request, response);
+    // @ts-ignore
+    expect(statusMocked).toHaveBeenCalledWith(500);
+    expect(jsonMocked.mock.lastCall[0].error.type).toBe("label-error");
+});
+
+test('updateLabel should call the service with the right parameters and return the updated label', async () => {
+    const jsonMocked = jest.fn();
+    const statusMocked = jest.fn().mockReturnValue({ json: jsonMocked });
+    const request: any = {
+        ...getMockedUser(),
+        params: {
+            labelId: randomUUID(),
+        },
+        body: {
+            name: "newerLabel",
+        }
+    };
+    const response: any = {
+        status: statusMocked
+    };
+
+    const returnValue = {};
+    const mockedUpdateLabel = jest.fn().mockReturnValue(returnValue);
+    // @ts-ignore
+    labelsService.updateLabel = mockedUpdateLabel
+    // @ts-ignore
+    labelsService.isOwner = jest.fn().mockReturnValue(true);
+
+    // @ts-ignore
+    await labelsHandler.updateLabel(request, response);
+    // @ts-ignore
+    expect(statusMocked).toHaveBeenCalledWith(200);
+    expect(mockedUpdateLabel).toHaveBeenCalledWith(request.params.labelId, { name: request.body.name });
+    expect(jsonMocked).toHaveBeenCalledWith({ label: returnValue });
+});
+
 test('deleteLabel should return an error when no labelId is provided', async () => {
     const jsonMocked = jest.fn();
     const statusMocked = jest.fn().mockReturnValue({ json: jsonMocked });

--- a/src/interfaces/Bookmark/index.ts
+++ b/src/interfaces/Bookmark/index.ts
@@ -6,4 +6,6 @@ export type Bookmark = {
     title?: string;
     user_id: string;
     labels?: EmbeddedLabel[];
+    created_at?: Date;
+    updated_at?: Date;
 };

--- a/src/interfaces/Label/index.ts
+++ b/src/interfaces/Label/index.ts
@@ -2,6 +2,8 @@ export type Label = {
     id: string;
     name: string;
     user_id: string;
+    created_at?: Date;
+    updated_at?: Date;
 };
 
 export type EmbeddedLabel = {

--- a/src/main.ts
+++ b/src/main.ts
@@ -95,6 +95,7 @@ app.delete('/bookmarks/:bookmarkId/labels/:labelId', passport.authenticate('sess
 
 app.get('/labels', passport.authenticate('session'), usersHandler.verifyLoggedIn, labelsHandler.getLabels);
 app.post('/labels', passport.authenticate('session'), usersHandler.verifyLoggedIn, labelsHandler.createLabel);
+app.put('/labels/:labelId', passport.authenticate('session'), usersHandler.verifyLoggedIn, labelsHandler.updateLabel);
 app.delete('/labels/:labelId', passport.authenticate('session'), usersHandler.verifyLoggedIn, labelsHandler.deleteLabel);
 
 // Start server

--- a/src/main.ts
+++ b/src/main.ts
@@ -88,6 +88,7 @@ app.post('/logout', passport.authenticate('session'), usersHandler.verifyLoggedI
 
 app.get('/bookmarks', passport.authenticate('session'), usersHandler.verifyLoggedIn, bookmarksHandler.getBookmarks);
 app.post('/bookmarks', passport.authenticate('session'), usersHandler.verifyLoggedIn, bookmarksHandler.addBookmark);
+app.delete('/bookmarks/:bookmarkId', passport.authenticate('session'), usersHandler.verifyLoggedIn, bookmarksHandler.deleteBookmark);
 app.post('/bookmarks/:bookmarkId/labels/:labelId', passport.authenticate('session'), usersHandler.verifyLoggedIn, bookmarksHandler.addLabelToBookmark);
 app.delete('/bookmarks/:bookmarkId/labels/:labelId', passport.authenticate('session'), usersHandler.verifyLoggedIn, bookmarksHandler.removeLabelFromBookmark);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -88,6 +88,7 @@ app.post('/logout', passport.authenticate('session'), usersHandler.verifyLoggedI
 
 app.get('/bookmarks', passport.authenticate('session'), usersHandler.verifyLoggedIn, bookmarksHandler.getBookmarks);
 app.post('/bookmarks', passport.authenticate('session'), usersHandler.verifyLoggedIn, bookmarksHandler.addBookmark);
+app.put('/bookmarks/:bookmarkId', passport.authenticate('session'), usersHandler.verifyLoggedIn, bookmarksHandler.updateBookmark);
 app.delete('/bookmarks/:bookmarkId', passport.authenticate('session'), usersHandler.verifyLoggedIn, bookmarksHandler.deleteBookmark);
 app.post('/bookmarks/:bookmarkId/labels/:labelId', passport.authenticate('session'), usersHandler.verifyLoggedIn, bookmarksHandler.addLabelToBookmark);
 app.delete('/bookmarks/:bookmarkId/labels/:labelId', passport.authenticate('session'), usersHandler.verifyLoggedIn, bookmarksHandler.removeLabelFromBookmark);

--- a/src/services/Bookmarks/index.ts
+++ b/src/services/Bookmarks/index.ts
@@ -1,3 +1,4 @@
+import { Bookmark } from "../../interfaces/Bookmark";
 import BookmarksStore from "../../stores/Bookmarks";
 
 export default class BookmarksService {
@@ -13,6 +14,10 @@ export default class BookmarksService {
 
     public addBookmark = async ({ url, title, userId }: { url: string, title?: string, userId: string }) => {
         return await this.bookmarksStore.addBookmark({ url, title, userId });
+    }
+
+    public updateBookmark = async (bookmarkId: string, fieldsToUpdate: Pick<Bookmark, 'url' | 'title'>) => {
+        return await this.bookmarksStore.updateBookmark(bookmarkId, fieldsToUpdate);
     }
 
     public deleteBookmark = async (bookmarkId: string) => {

--- a/src/services/Bookmarks/index.ts
+++ b/src/services/Bookmarks/index.ts
@@ -12,18 +12,19 @@ export default class BookmarksService {
     };
 
     public addBookmark = async ({ url, title, userId }: { url: string, title?: string, userId: string }) => {
-        const bookmark = this.bookmarksStore.addBookmark({ url, title, userId });
-        return bookmark;
+        return await this.bookmarksStore.addBookmark({ url, title, userId });
+    }
+
+    public deleteBookmark = async (bookmarkId: string) => {
+        return await this.bookmarksStore.deleteBookmark(bookmarkId);
     }
 
     public addLabelToBookmark = async ({ bookmarkId, labelId }: { bookmarkId: string, labelId: string }) => {
-        const bookmark = this.bookmarksStore.addLabelToBookmark({ bookmarkId, labelId });
-        return bookmark;
+        return await this.bookmarksStore.addLabelToBookmark({ bookmarkId, labelId });
     }
 
     public removeLabelFromBookmark = async ({ bookmarkId, labelId }: { bookmarkId: string, labelId: string }) => {
-        const bookmark = this.bookmarksStore.removeLabelFromBookmark({ bookmarkId, labelId });
-        return bookmark;
+        return await this.bookmarksStore.removeLabelFromBookmark({ bookmarkId, labelId });
     }
 
     public isOwner = async ({ bookmarkId, userId }: { bookmarkId: string, userId: string }) => {

--- a/src/services/Labels/index.ts
+++ b/src/services/Labels/index.ts
@@ -1,3 +1,4 @@
+import { Label } from "../../interfaces/Label";
 import LabelsStore from "../../stores/Labels";
 
 export default class LabelsService {
@@ -12,13 +13,15 @@ export default class LabelsService {
     };
 
     public createLabel = async ({ name, userId }: { name: string, userId: string }) => {
-        const label = this.labelsStore.createLabel({ name, userId });
-        return label;
+        return await this.labelsStore.createLabel({ name, userId });
+    }
+
+    public updateLabel = async (labelId: string, fieldsToUpdate: Pick<Label, 'name'>) => {
+        return await this.labelsStore.updateLabel(labelId, fieldsToUpdate);
     }
 
     public deleteLabel = async ({ labelId, userId }: { labelId: string, userId: string }) => {
-        const label = this.labelsStore.deleteLabel(labelId, userId);
-        return label;
+        return await this.labelsStore.deleteLabel(labelId, userId);
     }
 
     public isOwner = async ({ labelId, userId }: { labelId: string, userId: string }) => {

--- a/src/stores/Bookmarks/index.ts
+++ b/src/stores/Bookmarks/index.ts
@@ -120,6 +120,25 @@ export default class BookmarksStore {
             return new BookmarkError("There was an error saving the bookmark");
         }
     };
+    public updateBookmark = async (bookmarkId: string, fieldsToUpdate: Pick<Bookmark, 'url' | 'title'>): Promise<Bookmark | BookmarkError> => {
+        try {
+            const updatedBookmarkResult = await this.getTable().where({
+                id: bookmarkId,
+            }).update({ ...fieldsToUpdate, updated_at: new Date() }).returning(['id', 'url', 'title', 'user_id']);
+            if (!updatedBookmarkResult[0]) {
+                return new BookmarkError();
+            }
+            const updatedBookmark = updatedBookmarkResult[0];
+            return {
+                id: bookmarkId,
+                url: updatedBookmark.url,
+                title: updatedBookmark.title,
+                user_id: updatedBookmark.user_id
+            };
+        } catch (err) {
+            return new BookmarkError("There was an error updating the bookmark");
+        }
+    }
 
     public deleteBookmark = async (bookmarkId: string): Promise<true | BookmarkError> => {
         try {

--- a/src/stores/Bookmarks/index.ts
+++ b/src/stores/Bookmarks/index.ts
@@ -1,6 +1,6 @@
 import { Knex } from "knex";
 import { Bookmark } from "../../interfaces/Bookmark";
-import { BookmarkAlreadyExistsError, BookmarkAlreadyHasLabelError, BookmarkDoesNotHaveLabelError, BookmarkError, BookmarkLabelError } from "../../errors";
+import { BookmarkAlreadyExistsError, BookmarkAlreadyHasLabelError, BookmarkDoesNotExistError, BookmarkDoesNotHaveLabelError, BookmarkError, BookmarkLabelError } from "../../errors";
 import { randomUUID } from "crypto";
 import { LabelsBookmarks } from "../../interfaces/Bookmark/labelsbookmarks";
 
@@ -121,6 +121,21 @@ export default class BookmarksStore {
         }
     };
 
+    public deleteBookmark = async (bookmarkId: string): Promise<true | BookmarkError> => {
+        try {
+            const deletionResult = await this.getTable().where('id', bookmarkId).delete();
+            if (deletionResult === 0) {
+                return new BookmarkDoesNotExistError(`The bookmark with ID: ${bookmarkId} does not exist`);
+            }
+            if (deletionResult === 1) {
+                return true;
+            }
+            return new BookmarkError("There was an error deleting the bookmark");
+        } catch (err) {
+            return new BookmarkError("There was an error deleting the bookmark");
+        }
+    }
+
     public addLabelToBookmark = async ({ bookmarkId, labelId }: { bookmarkId: string, labelId: string }): Promise<true | BookmarkLabelError | BookmarkAlreadyHasLabelError> => {
         try {
             await this.getBookmarksLabelsTable().insert({
@@ -154,10 +169,14 @@ export default class BookmarksStore {
         }
     }
 
-    public isOwner = async ({ bookmarkId, userId }: { bookmarkId: string, userId: string }): Promise<true | false | BookmarkError> => {
+    public isOwner = async ({ bookmarkId, userId }: { bookmarkId: string, userId: string }): Promise<true | false | BookmarkDoesNotExistError | BookmarkError> => {
         try {
-            const result = await this.getTable().where('id', bookmarkId).andWhere('user_id', userId).orderBy("created_at", "desc");
+            const result = await this.getTable().where('id', bookmarkId);
             if (result.length !== 1) {
+                return new BookmarkDoesNotExistError(`The bookmark with id: ${bookmarkId} does not exist`);
+            }
+
+            if (result[0].user_id !== userId) {
                 return false;
             }
             return true;

--- a/src/stores/Bookmarks/index.ts
+++ b/src/stores/Bookmarks/index.ts
@@ -126,7 +126,7 @@ export default class BookmarksStore {
                 id: bookmarkId,
             }).update({ ...fieldsToUpdate, updated_at: new Date() }).returning(['id', 'url', 'title', 'user_id']);
             if (!updatedBookmarkResult[0]) {
-                return new BookmarkError();
+                return new BookmarkError("There was an error updating the bookmark");
             }
             const updatedBookmark = updatedBookmarkResult[0];
             return {


### PR DESCRIPTION
Before being able to start interfacing with this service from a client perspective, there is a minimum of functionality that needs to be present. 

I consider users + bookmarks + labels the bare minimum that is usable, and all entities are there now, but there were some endpoints missing for some of them and this PR addresses that.

## Acceptance criteria

- [x] Update bookmark
- [x] Delete bookmark
- [x] Update label
